### PR TITLE
Fix Node version check not working

### DIFF
--- a/src/dev.js
+++ b/src/dev.js
@@ -1,4 +1,4 @@
-if (!parseInt(process.version.substring(1, 3)) >= 15) {
+if (parseInt(process.version.substring(1, 3)) < 15) {
   console.error(`Node v15 or above required, aborting`);
   process.exit();
 }


### PR DESCRIPTION
Fixing 2 issues of current version check:
 - there was an `!` infront of `parseInt()`, which technically means it checked whether `false` or `true` is *higher* than 15
 - Use `<` instead of `>=` (as `>=` would only throw an error if someone runs node.js v15 or above)
