### PR TITLE
Fixed PCCompat issue with commands

### DIFF
--- a/moduleWrappers/powercord/global/commands.js
+++ b/moduleWrappers/powercord/global/commands.js
@@ -1,5 +1,5 @@
 const sendMessage = goosemodScope.webpackModules.findByProps('sendMessage', 'receiveMessage').sendMessage;
-const getChannelId = goosemodScope.webpackModules.findByProps('getChannelId').getChannelId;
+const getChannelId = goosemodScope.webpackModules.findByProps('getLastSelectedChannelId', 'getChannelId').getChannelId;
 
 export const registerCommand = ({ command, alias, description, usage, executor }) => {
   // TODO: implement alias


### PR DESCRIPTION
PCCompat used the wrong webpack module after an update, so when using a command that should send a message it would error and lock the message bar until the user changed channels.
Thanks to @1Lighty for the info on what correction to make after I had identified the issue.